### PR TITLE
Do not left join when converting attendees

### DIFF
--- a/src/Oro/Bundle/CalendarBundle/Migrations/Schema/v1_13/ConvertCalendarEventOwnerToAttendee.php
+++ b/src/Oro/Bundle/CalendarBundle/Migrations/Schema/v1_13/ConvertCalendarEventOwnerToAttendee.php
@@ -67,8 +67,8 @@ INSERT INTO oro_calendar_event_attendee
 SELECT
     $values
 FROM oro_calendar_event AS ce
-    LEFT JOIN oro_calendar c ON ce.calendar_id = c.id
-    LEFT JOIN oro_user u ON c.user_owner_id = u.id;
+    JOIN oro_calendar c ON ce.calendar_id = c.id
+    JOIN oro_user u ON c.user_owner_id = u.id;
 EOD;
 
         $this->logQuery($logger, $sql);


### PR DESCRIPTION
# Summary
Attendees are a new concept in Oro 1.10. An attendee is a "guest" to a calendar event, now in their own table. Due to this a migration was required, and supplied as part of the 1.10 upgrade. However, an issue comes of this.
[Context here](https://github.com/oroinc/platform/blob/1.10/src/Oro/Bundle/CalendarBundle/Migrations/Schema/v1_13/ConvertCalendarEventOwnerToAttendee.php#L65-L71)
```php
$sql = <<<EOD
INSERT INTO oro_calendar_event_attendee
    ($columns)
SELECT
    $values
FROM oro_calendar_event AS ce
    LEFT JOIN oro_calendar c ON ce.calendar_id = c.id
    LEFT JOIN oro_user u ON c.user_owner_id = u.id;
EOD;
```
As we can see here, the migration takes all the current calendar events, left joined with their individual calendars and users, and then inserted into the attendee table. This is perfectly fine when an event has a "guest", however, if there are no guests associated with the event, a null attendee is then inserted. This in turn causes the validation to fail when attempting to edit a user, since an attendee (which shouldn't exist) has a null email or name. What this PR does is simply remove the left join, and only insert attendees when an event actually has a guest.