### PR TITLE
Revert choice-tree-filter

### DIFF
--- a/src/Oro/Bundle/FilterBundle/Filter/ChoiceTreeFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/ChoiceTreeFilter.php
@@ -59,22 +59,8 @@ class ChoiceTreeFilter extends AbstractFilter
     public function getMetadata()
     {
         $metadata = parent::getMetadata();
-
-        $entities = [];
-
-        if ($this->getOr('className') && $this->state) {
-            $data = $this->parseData($this->state);
-
-            $event = new ChoiceTreeFilterLoadDataEvent($this->getOr('className'), $data['value']);
-            $this->eventDispatcher->dispatch(ChoiceTreeFilterLoadDataEvent::EVENT_NAME, $event);
-            $entities = $event->getData();
-        }
-
         $metadata[FilterUtility::TYPE_KEY] = 'choice-tree';
-        $metadata['data'] = $entities;
-        $metadata['autocomplete_alias'] = $this->getAutocompleteAlias();
-        $metadata['autocomplete_url'] = $this->getAutocompleteUrl();
-        $metadata['renderedPropertyName'] = $this->getRenderedPropertyName();
+        $metadata['data'] = $this->params['options']['data'];
 
         return $metadata;
     }

--- a/src/Oro/Bundle/FilterBundle/Resources/views/Js/default_templates.js.twig
+++ b/src/Oro/Bundle/FilterBundle/Resources/views/Js/default_templates.js.twig
@@ -195,6 +195,12 @@
 </script>
 <script type="text/template" id="choice-tree-template">
     <div class="filter-item oro-drop choice-tree-filter">
+        <input type="text" name="search" value="" class="choice-tree-filter-search"/>
+        <div class="buttons">
+            <span class="button-all active" data-mode="all'"><%- _.__("oro.filter.choice-tree.all") %></span> |
+            <span class="button-selected" data-mode="selected"><%- _.__("oro.filter.choice-tree.selected") %></span>
+        </div>
+        <div class="list"></div>
         <input type="hidden" name="value">
         <input type="hidden" name="type">
         <div class="oro-action">

--- a/src/Oro/Bundle/OrganizationBundle/Filter/BusinessUnitChoiceFilter.php
+++ b/src/Oro/Bundle/OrganizationBundle/Filter/BusinessUnitChoiceFilter.php
@@ -44,19 +44,6 @@ class BusinessUnitChoiceFilter extends ChoiceTreeFilter
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getMetadata()
-    {
-        $metadata = parent::getMetadata();
-
-        if (!$metadata['autocomplete_alias']) {
-            $metadata['autocomplete_alias'] = 'business_units_tree_search_handler';
-        }
-
-        return $metadata;
-    }
-    /**
      * {@inheritDoc}
      */
     public function parseData($data)


### PR DESCRIPTION
# Summary
This PR reverts the use of select2 when using the tree choice filter and instead uses the old functionality of having all the required data dumped on the page at load time.