### PR TITLE
[WIT-581] Suppress continue warning messages in PHP 7.3

### DIFF
--- a/src/Oro/Bundle/DistributionBundle/Error/ErrorHandler.php
+++ b/src/Oro/Bundle/DistributionBundle/Error/ErrorHandler.php
@@ -95,6 +95,21 @@ class ErrorHandler
             return true;
         }
 
+        /**
+         * PHP 7.3 introduced a new warning when calling the "continue" operator as part of switch
+         * control flow. This warning does not change the behaviour of continue when called in this 
+         * way, but rather is an alert to prevent accidental masking of errors.
+         * 
+         * As with the above, this is used extensively in code. As such, it would be too large 
+         * a task to individually suppress them. Instead, we can safely globally silence 
+         * the warning here.
+         * 
+         * @see https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch
+         */
+        if ($string == '"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?') {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
# About

As part of the PHP 7.3 upgrade, a new warning was raised in PHP regarding use of the "continue" statement in switch control flow statements. Whilst the upgrade does not change behaviour when calling continue, this warning is meant to inform developers about calling the correct system call (i.e. break vs continue 2).

As such, we can safely ignore this warning - as otherwise a large number will be raised during start up of the application and usage (in the same way as the "count" warning in PHP 7.2)

This change is as part of enabling PHP 7.3 support - See https://citizensadvice.atlassian.net/browse/WIT-581