### PR TITLE
Feature/hide user popout

### DIFF
--- a/src/Oro/Bundle/FormBundle/Resources/views/Form/fields.html.twig
+++ b/src/Oro/Bundle/FormBundle/Resources/views/Form/fields.html.twig
@@ -544,7 +544,13 @@
             {{ form_widget(form) }}
 
             {% if isButtonsEnabled %}
-                <button class="add-on btn entity-select-btn"><i class="icon-bars"></i></button>
+                {% if form.vars.button_disabled is defined %}
+                    {% if not form.vars.button_disabled %}
+                        <button class="add-on btn entity-select-btn"><i class="icon-bars"></i></button>
+                    {% endif %}
+                {% else %}
+                    <button class="add-on btn entity-select-btn"><i class="icon-bars"></i></button>
+                {% endif %}
 
                 {% if form.vars.create_enabled %}
                     <button class="btn entity-create-btn"><i class="icon-plus"></i></button>

--- a/src/Oro/Bundle/NoteBundle/Entity/Note.php
+++ b/src/Oro/Bundle/NoteBundle/Entity/Note.php
@@ -75,38 +75,11 @@ class Note extends ExtendNote implements DatesAwareInterface, UpdatedByAwareInte
     protected $organization;
 
     /**
-     * @var string $message
-     *
-     * @ORM\Column(name="message", type="text", nullable=false)
-     */
-    protected $message;
-
-    /**
      * @return int
      */
     public function getId()
     {
         return $this->id;
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return Note
-     */
-    public function setMessage($message)
-    {
-        $this->message = $message;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMessage()
-    {
-        return $this->message;
     }
 
     /**

--- a/src/Oro/Bundle/NoteBundle/Resources/config/validation.yml
+++ b/src/Oro/Bundle/NoteBundle/Resources/config/validation.yml
@@ -1,6 +1,4 @@
 Oro\Bundle\NoteBundle\Entity\Note:
     properties:
-        message:
-            - NotBlank:     ~
         organization:
             - NotBlank: ~


### PR DESCRIPTION
This PR includes the work from two branches, `hide_user_popout` and `remove_message_property`.

The changes to the fields template were done to support a new field option created in https://github.com/citizensadvice/witnessbox/pull/368. It allows for hiding the popout datagrid found next to the user select dropdown by using the option `button_disabled`.

The message property and validation were removed from the Note entity to allow for saving of Notes through the actions tab on the Witness page. This is necessary as the validation couldn't be overwritten, and once removed would fall back to the entity annotations and still fail.