### PR TITLE
[WIT-651] Refactor search sidebar

### DIFF
--- a/src/Oro/Bundle/SearchBundle/Controller/SearchController.php
+++ b/src/Oro/Bundle/SearchBundle/Controller/SearchController.php
@@ -7,7 +7,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -15,7 +14,6 @@ use Oro\Bundle\SearchBundle\Provider\ResultStatisticsProvider;
 use Oro\Bundle\SecurityBundle\Annotation\Acl;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Oro\Bundle\SearchBundle\Event\PrepareResultItemEvent;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class SearchController extends Controller
 {
@@ -111,14 +109,13 @@ class SearchController extends Controller
         }
 
         $entities = $this->get('oro_search.index')->getAllowedEntitiesListAliases();
-
         $configManager = $this->get('oro_entity_config.config_manager');
 
         $icons = [];
 
         foreach ($entities as $className => $alias) {
             $entityConfig = new EntityConfigId('entity', $className);
-            $configs      = $configManager->getConfig($entityConfig);
+            $configs = $configManager->getConfig($entityConfig);
 
             $icon = $configs->get('icon');
 

--- a/src/Oro/Bundle/SearchBundle/Resources/views/Search/searchResults.html.twig
+++ b/src/Oro/Bundle/SearchBundle/Resources/views/Search/searchResults.html.twig
@@ -18,28 +18,29 @@
         </form>
     </div>
 
-    {% if groupedResults is defined and '' in groupedResults|keys and groupedResults[''].count > 0 or groupedResults|length > 1 %}
-        <div class="oro-page collapsible-sidebar clearfix">
-            <div class="oro-page-sidebar search-entity-types-column dropdown">
-                <a href="javascript: void(0);" class="dropdown-toggle" data-toggle="dropdown">
-                    <i class="icon-filter"></i>
-                    {% if selectedResult %}
-                        {% if selectedResult.class %}{{ selectedResult.label }}{% else %}{{ 'oro.search.result.all'|trans }}{% endif %}
-                        ({{ selectedResult.count }}) <i class="icon-sort-down"></i>
-                    {% endif %}
-                </a>
-                <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu">
-                {% for alias, type in groupedResults %}
-                    {% set selected = alias == from %}
-                    {% if type.class %}
-                        {% set label = type.label %}
-                        {% set iconClass = type.icon %}
-                    {% else %}
-                        {% set label = 'oro.search.result.all'|trans %}
-                        {% set iconClass = 'icon-search' %}
-                    {% endif %}
+    <div class="oro-page collapsible-sidebar clearfix">
+        <div class="oro-page-sidebar search-entity-types-column dropdown">
+            <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu">
+                {% set searchEntities = [] %}
+                {% for className, alias in entities %}
+                    {% set entityType = oro_entity_config_value(className, 'label')|trans %}
+                    {% set searchEntities = searchEntities|merge({(alias) : entityType}) %}
+                {% endfor %}
 
-                    {% if iconClass is empty %}
+                <li{% if not from %} class="selected"{% endif %}>
+                    <a href="{{ path('oro_search_results', { search: searchString }) }}">
+                        {% if not from %}<i class="icon-chevron-right pull-right"></i>{% endif %}
+                        <i class="icon-search"></i>
+                        {{ 'oro.search.result.all'|trans }}
+                    </a>
+                </li>
+
+                {% for alias, name in searchEntities|sort %}
+                    {% set selected = alias == from %}
+
+                    {% if icons[alias] is defined %}
+                        {% set iconClass = icons[alias] %}
+                    {% else %}
                         {% set iconClass = 'icon-file' %}
                     {% endif %}
 
@@ -47,23 +48,18 @@
                         <a href="{{ path('oro_search_results', { from: alias, search: searchString }) }}">
                             {% if selected %}<i class="icon-chevron-right pull-right"></i>{% endif %}
                             <i class="{{ iconClass }}"></i>
-                            {{ label }} ({{ type.count }})
+                            {{ name }}
                         </a>
                     </li>
                 {% endfor %}
-                </ul>
-            </div>
-            <div class="oro-page-body search-results-column">
-                <div id="search-result-grid">
-                    {{ dataGrid.renderGrid(gridName, {from: from, search: searchString}, { cssClass: 'search-grid grid-without-header' }) }}
-                </div>
+            </ul>
+        </div>
+
+        <div class="oro-page-body search-results-column">
+            <div id="search-result-grid">
+                {{ dataGrid.renderGrid(gridName, {from: from, search: searchString}, { cssClass: 'search-grid grid-without-header' }) }}
             </div>
         </div>
-    {% else %}
-    <div class="search-no-results">
-        {% trans %}No results were found to match your search.{% endtrans %}
-        <br />
-        {% trans %}Try modifying your search criteria or creating a new ...{% endtrans %}
     </div>
-    {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
# Refactor search sidebar

**Ticket:** https://citizensadvice.atlassian.net/browse/WIT-651

## Description

This PR removes the sidebar queries that run when performing a search via the searchbars on WB.

The process for running a search is as follows:

- Grab the selected filter (witness, all, etc) and the words from the search textbox.
- Run a query and count query for use in the sidebar.
- Loop through each item, finding icons, grouping by entity, counting items by entity etc.
- Output that data into a list (the sidebar).
- Send the previously used search words from the textbook and filter to the datagrid builder.
- Run the same queries (limited to 25 for pagination) to populate the results grid.

The new process is as follows:

- Grab the selected filter (witness, all, etc) and the words from the search textbox.
- Find entities and icons for the sidebar using entityconfig helpers and User permissions.
- Output that data into a list (the sidebar).
- Send the previously used search words from the textbook and filter to the datagrid builder.
- Run the same queries (limited to 25 for pagination) to populate the results grid.

The main benefit is that this completely skips two very intensive queries. This is fairly noticable for filtered queries since even though they are filtered, they would previously also run an unfiltered version of the query to obtain correct counts for every entity.

## Performance

Below you can find some numbers comparing search before and after the changes made in this PR.

### Before

Search term | Filter | Query time (ms) | Total time (ms)
-- | -- | -- | --
john | All | 11752 | 16599
john | Witness/Party | 7838 | 12826
chris | Trial/Case | 5703 | 10188

### After


Search term | Filter | Query time (ms) | Total time (ms)
-- | -- | -- | --
john | All | 6439 | 11933
john | Witness/Party | 1914 | 7377
chris | Trial/Case | 1742 | 7144

**Note:** All queries were ran 3 times and an average time was taken.

## User experience

Theres two main drawbacks to this work that require discussion with the team and CA.

1. The entities in the sidebar.

   This list now comes from the user permissions instead of the search data, the list matches exactly what is found in the filter next to the main searchbar. This means that if you run a search that return 0 witnesses for example, the witness option will still be available on the sidebar.

   This can be altered to hide certain items from the sidebar, things such as 'localization', 'roles' etc may not be necessary. While they are not available to all users (because of permissions) it may still be worth hiding some of these.

2. No count numbers in the sidebar.

   Previously, each entity would also have a count of records that link to it. For example if you run a search, you may see something like this in the sidebar:
   
   <img width="244" alt="Screenshot 2021-04-15 at 14 11 17" src="https://user-images.githubusercontent.com/54840294/114877466-34029700-9df7-11eb-9a2e-3301c23d8753.png">

   However, now you see the following with no counts:

   <img width="263" alt="Screenshot 2021-04-15 at 14 08 57" src="https://user-images.githubusercontent.com/54840294/114877493-3b29a500-9df7-11eb-95a8-b23f61b6d276.png">

Alternatively, we can just remove the sidebar completely to avoid any confusion.
