### PR TITLE
[WIT-263] Orphan removal

### DIFF
--- a/src/Oro/Bundle/AttachmentBundle/Resources/views/Form/fields.html.twig
+++ b/src/Oro/Bundle/AttachmentBundle/Resources/views/Form/fields.html.twig
@@ -20,7 +20,7 @@
                 <div id="{{ divId }}" class="well well-small oro_attachment_file">
                     {{ oro_file_view(parentEntity, fieldName, value) }}
                     {{ form_row(form.emptyFile) }}
-                    <button id = "{{ buttonId }}" class="btn btn-action btn-link" type="button" data-related="{{ form.emptyFile.vars.name }}"></button>
+                    <i id = "{{ buttonId }}" class="btn btn-link icon-remove remove-attachment attachment-icon" type="button" data-related="{{ form.emptyFile.vars.name }}"></i>
                 </div>
                 <script type="text/javascript">
                     require(['jquery'],

--- a/src/Oro/Bundle/EmailBundle/Entity/Manager/EmailOwnerManager.php
+++ b/src/Oro/Bundle/EmailBundle/Entity/Manager/EmailOwnerManager.php
@@ -232,8 +232,13 @@ class EmailOwnerManager
                 $this->emailAddressManager->getEntityManager()->persist($emailAddress);
                 $updatedEmailAddresses[] = $emailAddress;
             } elseif ($emailAddress->getOwner() !== $newOwner) {
-                $emailAddress->setOwner($newOwner);
-                $updatedEmailAddresses[] = $emailAddress;
+                // If newOwner is null, delete the address to prevent a floating record
+                if ($newOwner === null) {
+                    $this->emailAddressManager->getEntityManager()->remove($emailAddress);
+                } else {
+                    $emailAddress->setOwner($newOwner);
+                    $updatedEmailAddresses[] = $emailAddress;
+                }
             }
         }
 

--- a/src/Oro/Bundle/UserBundle/Entity/User.php
+++ b/src/Oro/Bundle/UserBundle/Entity/User.php
@@ -4,6 +4,7 @@ namespace Oro\Bundle\UserBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -732,6 +733,18 @@ class User extends ExtendUser implements
 
         if (array_diff_key($event->getEntityChangeSet(), array_flip($excludedFields))) {
             $this->updatedAt = new \DateTime('now', new \DateTimeZone('UTC'));
+        }
+    }
+
+    /**
+     * @ORM\PreRemove
+     */
+    public function preRemove(LifecycleEventArgs $args)
+    {
+        $entityManager = $args->getEntityManager();
+
+        foreach ($this->emails as $email) {
+            $entityManager->remove($email);
         }
     }
 

--- a/src/Oro/Bundle/UserBundle/Entity/User.php
+++ b/src/Oro/Bundle/UserBundle/Entity/User.php
@@ -749,7 +749,9 @@ class User extends ExtendUser implements
             $entityManager->remove($email);
         }
 
-        $entityManager->remove($this->email);
+        $email = $entityManager->getRepository('OroEmailBundle:EmailAddress')->findOneBy(['email' => $this->email]);
+
+        $entityManager->remove($email);
     }
 
     /**

--- a/src/Oro/Bundle/UserBundle/Entity/User.php
+++ b/src/Oro/Bundle/UserBundle/Entity/User.php
@@ -737,6 +737,8 @@ class User extends ExtendUser implements
     }
 
     /**
+     * Ensure any User emails are deleted when the User is.
+     *
      * @ORM\PreRemove
      */
     public function preRemove(LifecycleEventArgs $args)
@@ -746,6 +748,8 @@ class User extends ExtendUser implements
         foreach ($this->emails as $email) {
             $entityManager->remove($email);
         }
+
+        $entityManager->remove($this->email);
     }
 
     /**

--- a/src/Oro/Bundle/UserBundle/Entity/User.php
+++ b/src/Oro/Bundle/UserBundle/Entity/User.php
@@ -352,7 +352,7 @@ class User extends ExtendUser implements
     /**
      * @var Email[]|Collection
      *
-     * @ORM\OneToMany(targetEntity="Email", mappedBy="user", orphanRemoval=true, cascade={"persist"})
+     * @ORM\OneToMany(targetEntity="Email", mappedBy="user", orphanRemoval=true, cascade={"persist"}, orphanRemoval=true)
      * @ConfigField(
      *      defaultValues={
      *          "dataaudit"={


### PR DESCRIPTION
# Orphan removal

**Ticket:** https://citizensadvice.atlassian.net/browse/WIT-263

## Description

This PR makes some platform changes that are required for the orphan removal work.

The orphanRemoval property has been added to the email collection on Users. This ensures that emails are deleted when unlinked from a User using the 'X'  button on the User form. See: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/working-with-associations.html#orphan-removal

The button to delete a file attachment has been changed to the 'x' icon found on other entities. The standard icon is inconsistent and is sometimes even invisible. The new one looks like this (using css from WB):

<img width="339" alt="Screenshot 2021-05-07 at 14 40 01" src="https://user-images.githubusercontent.com/54840294/117458370-23e75e80-af42-11eb-9e55-5896b0650911.png">

Since emails are saved in two different tables, the final change is an additional check in the emailownermanager to delete an email address if it's owner (User) is set to null. This check needs to be specified in the code since there is no entity link to allow the use of orphan removal through doctrine.
