### PR TITLE
Escape dash in config annotation.

### DIFF
--- a/src/Oro/Bundle/ConfigBundle/Controller/Api/Rest/ConfigurationController.php
+++ b/src/Oro/Bundle/ConfigBundle/Controller/Api/Rest/ConfigurationController.php
@@ -52,7 +52,7 @@ class ConfigurationController extends FOSRestController
      * @param string $path The configuration section path. For example: look-and-feel/grid
      *
      * @Get("/configuration/{path}",
-     *      requirements={"path"="[\w-]+[\w-\/]*"}
+     *      requirements={"path"="[\w\-]+[\w\-\/]*"}
      * )
      * @ApiDoc(
      *      description="Get all configuration data of the specified section",


### PR DESCRIPTION
Prod WB is currently pointed to the `preg_match_error_fix` branch, we should merge this in so we can point it back to the `1.10` branch.