### PR TITLE
[WIT-821, WIT-822] Anonymised search indexes

### DIFF
--- a/src/Oro/Bundle/CalendarBundle/Resources/config/search.yml
+++ b/src/Oro/Bundle/CalendarBundle/Resources/config/search.yml
@@ -23,3 +23,7 @@ Oro\Bundle\CalendarBundle\Entity\CalendarEvent:
             name:                   end
             target_type:            datetime
             target_fields:          [end]
+        -
+            name:                   isAnonymised
+            target_type:            integer
+            target_fields:          [isAnonymised]

--- a/src/Oro/Bundle/SearchBundle/Engine/Orm.php
+++ b/src/Oro/Bundle/SearchBundle/Engine/Orm.php
@@ -199,10 +199,6 @@ class Orm extends AbstractEngine implements ProgressLoggerAwareInterface
                 continue;
             }
 
-            if (isset($data['integer']['isAnonymised'])) {
-                continue;
-            }
-
             $class = $this->doctrineHelper->getEntityClass($entity);
             $id    = $this->doctrineHelper->getSingleEntityIdentifier($entity);
 
@@ -221,11 +217,15 @@ class Orm extends AbstractEngine implements ProgressLoggerAwareInterface
                     ->setAlias($alias);
             }
 
-            $item->setTitle($this->getEntityTitle($entity))
+            if (isset($data['integer']['isAnonymised'])) {
+                $this->clearSearchIndexForSingleEntity($class, $id);
+            } else {
+                $item->setTitle($this->getEntityTitle($entity))
                 ->setChanged(false)
                 ->saveItemData($data);
 
-            $this->dbalStorer->addItem($item);
+                $this->dbalStorer->addItem($item);
+            }
 
             $hasSavedEntities = true;
         }
@@ -366,6 +366,29 @@ EOF;
             $query,
             [$entityName, $entityName, $entityName, $entityName, $entityName],
             [\PDO::PARAM_STR, \PDO::PARAM_STR, \PDO::PARAM_STR, \PDO::PARAM_STR, \PDO::PARAM_STR]
+        );
+    }
+
+    /**
+     * Clear all search indexes for a specific entity given a class and id
+     * 
+     * @param string $entityName
+     * @param int $id
+     */
+    protected function clearSearchIndexForSingleEntity($entityName, $id)
+    {
+        $query = <<<EOF
+DELETE FROM oro_search_index_integer  WHERE item_id IN (SELECT DISTINCT id FROM oro_search_item WHERE entity = ? AND record_id = ?);
+DELETE FROM oro_search_index_datetime WHERE item_id IN (SELECT DISTINCT id FROM oro_search_item WHERE entity = ? AND record_id = ?);
+DELETE FROM oro_search_index_decimal  WHERE item_id IN (SELECT DISTINCT id FROM oro_search_item WHERE entity = ? AND record_id = ?);
+DELETE FROM oro_search_index_text     WHERE item_id IN (SELECT DISTINCT id FROM oro_search_item WHERE entity = ? AND record_id = ?);
+DELETE FROM oro_search_item           WHERE entity = ?;
+EOF;
+
+        $this->getIndexManager()->getConnection()->executeQuery(
+            $query,
+            [$entityName, $id, $entityName, $id, $entityName, $id, $entityName, $id, $entityName],
+            [\PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR]
         );
     }
 

--- a/src/Oro/Bundle/SearchBundle/Engine/Orm.php
+++ b/src/Oro/Bundle/SearchBundle/Engine/Orm.php
@@ -382,13 +382,24 @@ DELETE FROM oro_search_index_integer  WHERE item_id IN (SELECT DISTINCT id FROM 
 DELETE FROM oro_search_index_datetime WHERE item_id IN (SELECT DISTINCT id FROM oro_search_item WHERE entity = ? AND record_id = ?);
 DELETE FROM oro_search_index_decimal  WHERE item_id IN (SELECT DISTINCT id FROM oro_search_item WHERE entity = ? AND record_id = ?);
 DELETE FROM oro_search_index_text     WHERE item_id IN (SELECT DISTINCT id FROM oro_search_item WHERE entity = ? AND record_id = ?);
-DELETE FROM oro_search_item           WHERE entity = ?;
+DELETE FROM oro_search_item           WHERE entity = ? AND record_id = ?;
 EOF;
 
         $this->getIndexManager()->getConnection()->executeQuery(
             $query,
-            [$entityName, $id, $entityName, $id, $entityName, $id, $entityName, $id, $entityName],
-            [\PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_INT, \PDO::PARAM_STR]
+            [$entityName, $id, $entityName, $id, $entityName, $id, $entityName, $id, $entityName, $id],
+            [
+                \PDO::PARAM_STR,
+                \PDO::PARAM_INT,
+                \PDO::PARAM_STR,
+                \PDO::PARAM_INT,
+                \PDO::PARAM_STR,
+                \PDO::PARAM_INT,
+                \PDO::PARAM_STR,
+                \PDO::PARAM_INT,
+                \PDO::PARAM_STR,
+                \PDO::PARAM_INT
+            ]
         );
     }
 

--- a/src/Oro/Bundle/SearchBundle/Engine/Orm.php
+++ b/src/Oro/Bundle/SearchBundle/Engine/Orm.php
@@ -199,6 +199,10 @@ class Orm extends AbstractEngine implements ProgressLoggerAwareInterface
                 continue;
             }
 
+            if (isset($data['integer']['isAnonymised'])) {
+                continue;
+            }
+
             $class = $this->doctrineHelper->getEntityClass($entity);
             $id    = $this->doctrineHelper->getSingleEntityIdentifier($entity);
 


### PR DESCRIPTION
# Anonymised search indexes

**Ticket:** https://citizensadvice.atlassian.net/browse/WIT-821 + https://citizensadvice.atlassian.net/browse/WIT-822

## Description

This PR is used alongside: https://github.com/citizensadvice/witnessbox/pull/433

It edits the search index system so that any change that includes `isAnonymised` will be deleted from the search indexes.

`isAnonymised` is now included in the search indexes (with this PR and the WB PR), however, it only appears in the data array if the value is equal to 1. Therefore we are able to check for it's existence and delete if found. The `isAnoymised` field and value should never actually be saved in the index tables.
